### PR TITLE
queue up events from extreme in the InOrder producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 - 2021-08-12
+
+### Changed
+
+- Changed the InOrderSubscription internals to buffer events from the
+  extreme subscription in a queue when there is no demand
+    - this unlocks the ability for this producer to emit multiple events
+      at once
+
 ## 0.4.0 - 2021-06-10
 
 ### Added

--- a/test/fixtures/my_linear_consumer.ex
+++ b/test/fixtures/my_linear_consumer.ex
@@ -13,15 +13,20 @@ defmodule MyInOrderConsumer do
   def init(opts) do
     test_proc = Keyword.fetch!(opts, :test_proc)
     subscribe_to = Keyword.fetch!(opts, :subscribe_to)
+    sleep_time = Keyword.fetch!(opts, :sleep_time)
 
-    {:consumer, test_proc, subscribe_to: subscribe_to}
+    {:consumer, {test_proc, sleep_time}, subscribe_to: subscribe_to}
   end
 
   @impl GenStage
-  def handle_events(events, _from, test_proc) do
+  def handle_events(events, _from, {test_proc, sleep_time}) do
+    if sleep_time |> is_integer() do
+      Process.sleep(sleep_time)
+    end
+
     events = Enum.map(events, fn {_producer, event} -> event end)
     send(test_proc, {:events, events})
 
-    {:noreply, [], test_proc}
+    {:noreply, [], {test_proc, sleep_time}}
   end
 end

--- a/test/fixtures/my_linear_supervisor.ex
+++ b/test/fixtures/my_linear_supervisor.ex
@@ -19,12 +19,14 @@ defmodule MyInOrderSupervisor do
       connection: ExtremeClient,
       stream_name: Keyword.fetch!(opts, :stream_name),
       restore_stream_position!: Keyword.fetch!(opts, :restore_stream_position!),
-      subscribe_on_init?: {Function, :identity, [true]}
+      subscribe_on_init?: {Function, :identity, [true]},
+      catch_up_chunk_size: Keyword.get(opts, :catch_up_chunk_size, 256)
     ]
 
     consumer_opts = [
       test_proc: Keyword.fetch!(opts, :test_proc),
-      subscribe_to: [{producer_name, max_demand: 1}]
+      subscribe_to: [{producer_name, max_demand: 1}],
+      sleep_time: Keyword.get(opts, :sleep_time)
     ]
 
     children = [


### PR DESCRIPTION
slack thread talking about the problem: https://cuatrohq.slack.com/archives/CMZFU35JL/p1628716542082800

In its current version, the kelvin InOrderSubscription will only ever emit one event at a time because when you dump an event into the GenStage built-in buffer, it's dispatched immediately. This PR switches out the producer's `:buffer` from being a single element to being a queue of events from the extreme subscription. This queue has its size limited so that it does not exceed the size of the configured reading chunk. The buffer queue gets filled up when the producer does not have any demand from the consumer but the extreme subscription is pushing events. It buffers the events by acknowledging the events from the extreme subscription (with a `{:reply, :ok, _events_to_dispatch = [], state}` return signature) and enqueueing them with `:queue.in/2`. When the consumer demands events, the producer pops as many events out of the queue as the consumer wishes while the queue has events to pop.